### PR TITLE
Add basic Mars Weight Calculator script

### DIFF
--- a/cli/mars_weight.py
+++ b/cli/mars_weight.py
@@ -1,7 +1,15 @@
+import sys
+
 def calculate_weight(earth_weight, factor):
     return earth_weight * factor
 
 def main():
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print("Usage: python mars_weight.py")
+        print("Then enter your Earth weight in kg when prompted.")
+        print("Example: 72.5")
+        return
+
     print("Mars Weight Calculator (CLI)")
     earth = input("Enter your weight on Earth in kilograms (e.g., 72.5): ")
 
@@ -24,3 +32,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
This PR adds the initial Python CLI script for the Mars Weight Calculator.
- Calculates equivalent weight on Moon, Mars, and ISS
- Includes input validation for non-numeric or negative values
- Provides clear user prompts
